### PR TITLE
Update member fetch

### DIFF
--- a/src/CorePayments.Infrastructure/Repository/MemberRepository.cs
+++ b/src/CorePayments.Infrastructure/Repository/MemberRepository.cs
@@ -22,7 +22,7 @@ namespace CorePayments.Infrastructure.Repository
 
         public async Task<(IEnumerable<Member>? members, string? continuationToken)> GetPagedMembers(int pageSize, string continuationToken)
         {
-            QueryDefinition query = new QueryDefinition("select * from c order by c.lastName desc");
+            QueryDefinition query = new QueryDefinition("select * from c order by c._ts desc");
 
             return await PagedQuery<Member>(query, pageSize, null, continuationToken);
         }


### PR DESCRIPTION
Ordering by the last insert/update of a member record in descending order as a temporary way of being able to find a newly created member record